### PR TITLE
Remove the added known host during cleanup

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -6,3 +6,5 @@ rm -fr \
     pc.img \
     seed.manifest
 
+# Remove the host key of the UC instance added during the initial ssh connection
+ssh-keygen -f ~/.ssh/known_hosts -R "[localhost]:8022"


### PR DESCRIPTION
This is to avoid remote host identifications warnings from the ssh client when testing subsequent UC instances.

Alternatively, we could add `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null` to the ssh command to not add the host key in the first place. A better approach but it makes the testing output harder to read. A good alternative if we disable xtrace in the bash script.